### PR TITLE
Add page level markdown

### DIFF
--- a/Js Tip/chrom extensions/reader-focus-extension/content.js
+++ b/Js Tip/chrom extensions/reader-focus-extension/content.js
@@ -256,6 +256,10 @@
         }
         sendResponse({ html: selectedHtml });
         return true; // 為了非同步 sendResponse，保持通道開啟
+      } else if (message.action === "getPageHtml") {
+        const html = document.documentElement.outerHTML;
+        sendResponse({ html });
+        return true;
       }
       return true; // 保持非同步回應
     };


### PR DESCRIPTION
## Summary
- add `copyPageAsMarkdown` context menu option
- support new `getPageHtml` action in content script

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849826b1cf8833087e1c7f4a5ad87d8