### PR TITLE
Fix extension clipboard copy

### DIFF
--- a/Js Tip/chrom extensions/reader-focus-extension/background.js
+++ b/Js Tip/chrom extensions/reader-focus-extension/background.js
@@ -4,6 +4,21 @@ try {
   console.error('無法載入 Turndown:', e);
 }
 
+function logHtmlSnippet(prefix, html) {
+  const maxLen = 200;
+  const snippet = html.length > maxLen
+    ? `${html.slice(0, 100)}...${html.slice(-100)}`
+    : html;
+  console.log(`${prefix}:`, snippet);
+}
+
+function logMarkdownPreview(prefix, markdown) {
+  const lines = markdown.split('\n');
+  const first = lines[0] || '';
+  const last = lines[lines.length - 1] || '';
+  console.log(`${prefix} 首行: ${first} | 末行: ${last}`);
+}
+
 function convertHtmlToMarkdown(html, removeHidden = false) {
   if (typeof TurndownService !== 'function') {
     throw new Error('TurndownService 未載入');
@@ -34,20 +49,27 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === 'copyAsMarkdown' && tab) {
     chrome.tabs.sendMessage(tab.id, { action: 'getSelectedHtml' }, (response) => {
-
       if (chrome.runtime.lastError) {
-        console.error("請求選取的 HTML 時發生錯誤:", chrome.runtime.lastError.message);
+        console.error('請求選取的 HTML 時發生錯誤:', chrome.runtime.lastError.message);
         return;
       }
       if (response && typeof response.html === 'string') {
+        logHtmlSnippet('取得選取 HTML', response.html);
         try {
           const markdownText = convertHtmlToMarkdown(response.html);
           if (markdownText) {
-            navigator.clipboard.writeText(markdownText)
-              .then(() => {
-                console.log('Markdown 已複製到剪貼簿。');
-              })
-              .catch(err => console.error('將 Markdown 複製到剪貼簿失敗:', err));
+            logMarkdownPreview('即將寫入剪貼簿', markdownText);
+            chrome.tabs.sendMessage(tab.id, { action: 'copyMarkdown', markdown: markdownText }, res => {
+              if (chrome.runtime.lastError) {
+                console.error('複製 Markdown 失敗:', chrome.runtime.lastError.message);
+                return;
+              }
+              if (res && res.success) {
+                logMarkdownPreview('複製完成', markdownText);
+              } else {
+                console.warn('內容腳本回報複製失敗');
+              }
+            });
           } else {
             console.warn('Markdown 轉換結果為空字串。');
           }
@@ -55,33 +77,40 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
           console.error('HTML 轉換為 Markdown 失敗:', err);
         }
       } else {
-        console.warn("未從內容腳本收到 HTML 或回應格式無效。");
+        console.warn('未從內容腳本收到 HTML 或回應格式無效。');
       }
     });
-  } else if (info.menuItemId === "copyPageAsMarkdown" && tab) {
+  } else if (info.menuItemId === 'copyPageAsMarkdown' && tab) {
     chrome.tabs.sendMessage(tab.id, { action: 'getPageHtml' }, (response) => {
       if (chrome.runtime.lastError) {
-        console.error("請求頁面 HTML 時發生錯誤:", chrome.runtime.lastError.message);
+        console.error('請求頁面 HTML 時發生錯誤:', chrome.runtime.lastError.message);
         return;
       }
       if (response && typeof response.html === 'string') {
+        logHtmlSnippet('取得整頁 HTML', response.html);
         try {
           const markdownText = convertHtmlToMarkdown(response.html, true);
           if (markdownText) {
-            navigator.clipboard.writeText(markdownText)
-              .then(() => {
-                console.log('Markdown 已複製到剪貼簿。');
-              })
-              .catch(err => console.error('將 Markdown 複製到剪貼簿失敗:', err));
+            logMarkdownPreview('即將寫入剪貼簿', markdownText);
+            chrome.tabs.sendMessage(tab.id, { action: 'copyMarkdown', markdown: markdownText }, res => {
+              if (chrome.runtime.lastError) {
+                console.error('複製 Markdown 失敗:', chrome.runtime.lastError.message);
+                return;
+              }
+              if (res && res.success) {
+                logMarkdownPreview('複製完成', markdownText);
+              } else {
+                console.warn('內容腳本回報複製失敗');
+              }
+            });
           } else {
             console.warn('Markdown 轉換結果為空字串。');
           }
         } catch (err) {
           console.error('HTML 轉換為 Markdown 失敗:', err);
-
         }
       } else {
-        console.warn("未從內容腳本收到 HTML 或回應格式無效。");
+        console.warn('未從內容腳本收到 HTML 或回應格式無效。');
       }
     });
   }

--- a/Js Tip/chrom extensions/reader-focus-extension/content.js
+++ b/Js Tip/chrom extensions/reader-focus-extension/content.js
@@ -261,6 +261,27 @@
         const html = clone.outerHTML;
         sendResponse({ html });
         return true;
+      } else if (message.action === 'copyMarkdown') {
+        const text = message.markdown || '';
+        const lines = text.split('\n');
+        const first = lines[0] || '';
+        const last = lines[lines.length - 1] || '';
+        console.log(`[Content] 開始寫入剪貼簿 首行: ${first} | 末行: ${last}`);
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text)
+            .then(() => {
+              console.log(`[Content] 已完成複製 首行: ${first} | 末行: ${last}`);
+              sendResponse({ success: true });
+            })
+            .catch(err => {
+              console.error('[Content] 複製 Markdown 失敗:', err);
+              sendResponse({ success: false });
+            });
+        } else {
+          console.warn('[Content] Clipboard API 不可用');
+          sendResponse({ success: false });
+        }
+        return true;
       }
       return true; // 保持非同步回應
     };


### PR DESCRIPTION
## Summary
- improve html2md logging
- copy markdown via content script for clipboard support

## Testing
- `node --check 'Js Tip/chrom extensions/reader-focus-extension/background.js'`
- `node --check 'Js Tip/chrom extensions/reader-focus-extension/content.js'`


------
https://chatgpt.com/codex/tasks/task_e_684a649fe6d48330b9970d2dcf8d01eb