### PR TITLE
Add static page listing router

### DIFF
--- a/Python Sample/fatsever/app/main.py
+++ b/Python Sample/fatsever/app/main.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text
 import starlette.formparsers
 
-from app.routers import upload, ytdownloader, file_handler, chat
+from app.routers import upload, ytdownloader, file_handler, chat, pages
 from app.routers.upload import calculate_total_size, CACHE
 
 from app.services.file_service import get_file_list, get_video_files
@@ -77,7 +77,7 @@ app.add_middleware(
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "app" / "templates"))
-app.mount("/static", StaticFiles(directory="app/static"), name="static")
+app.mount("/assets", StaticFiles(directory="app/static"), name="assets")
 
 app.mount("/img", StaticFiles(directory="img"), name="img")
 app.mount("/video", StaticFiles(directory="video"), name="video")
@@ -88,6 +88,7 @@ app.include_router(upload.router, prefix="/api", tags=["upload"])
 app.include_router(ytdownloader.router, prefix="/api", tags=["ytdownloader"])
 app.include_router(file_handler.router)
 app.include_router(chat.router)
+app.include_router(pages.router)
 
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):

--- a/Python Sample/fatsever/app/routers/pages.py
+++ b/Python Sample/fatsever/app/routers/pages.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from fastapi import APIRouter, Request, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+PAGES_DIR = BASE_DIR / "templates" / "pages"
+
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+router = APIRouter(prefix="/static", tags=["static-pages"])
+
+
+def _list_page_names():
+    return [p.stem for p in PAGES_DIR.glob("*.html") if p.is_file()]
+
+
+@router.get("/", response_class=HTMLResponse)
+async def list_pages(request: Request):
+    pages = _list_page_names()
+    return templates.TemplateResponse("pages/list_pages.html", {"request": request, "pages": pages})
+
+
+@router.get("/{page_name}", response_class=HTMLResponse)
+async def show_page(page_name: str, request: Request):
+    file_path = PAGES_DIR / f"{page_name}.html"
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Page not found")
+    template_name = f"pages/{page_name}.html"
+    return templates.TemplateResponse(template_name, {"request": request})

--- a/Python Sample/fatsever/app/templates/base.html
+++ b/Python Sample/fatsever/app/templates/base.html
@@ -6,7 +6,7 @@
   <title>{% block title %}FatAPI{% endblock %}</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"/>
-  <link rel="stylesheet" href="/static/css/index.css"/>
+  <link rel="stylesheet" href="/assets/css/index.css"/>
 </head>
 <body>
   {% block navigation %}
@@ -65,6 +65,6 @@
   </dialog>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js"></script>
-  <script src="/static/js/index.js"></script>
+  <script src="/assets/js/index.js"></script>
 </body>
 </html>

--- a/Python Sample/fatsever/app/templates/chat.html
+++ b/Python Sample/fatsever/app/templates/chat.html
@@ -9,7 +9,7 @@
     <input type="text" id="messageInput" class="form-control" placeholder="輸入訊息" autocomplete="off">
     <button id="sendBtn" class="btn btn-primary">送出</button>
   </div>
-  <script src="/static/js/chat.js"></script>
+  <script src="/assets/js/chat.js"></script>
   {% endblock content %}
 </div>
 {% endblock container %}

--- a/Python Sample/fatsever/app/templates/pages/1.html
+++ b/Python Sample/fatsever/app/templates/pages/1.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Page 1</h2>
+<p>這是靜態頁面 1 的內容。</p>
+{% endblock %}

--- a/Python Sample/fatsever/app/templates/pages/2.html
+++ b/Python Sample/fatsever/app/templates/pages/2.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Page 2</h2>
+<p>這是靜態頁面 2 的內容。</p>
+{% endblock %}

--- a/Python Sample/fatsever/app/templates/pages/3.html
+++ b/Python Sample/fatsever/app/templates/pages/3.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Page 3</h2>
+<p>這是靜態頁面 3 的內容。</p>
+{% endblock %}

--- a/Python Sample/fatsever/app/templates/pages/list_pages.html
+++ b/Python Sample/fatsever/app/templates/pages/list_pages.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Static Pages</h2>
+<ul>
+  {% for page in pages %}
+  <li><a href="/static/{{ page }}">{{ page }}</a></li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- serve static assets under `/assets`
- create router for static HTML pages
- list available pages at `/static`

## Testing
- `pytest Python Sample/palindrome_number_test.py Python Sample/roman_to_integer_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6864d311bc508330a6ccb4d7d4f37c5f