### PR TITLE
Fix websocket scheme for secure pages

### DIFF
--- a/Python Sample/fatsever/app/static/js/chat.js
+++ b/Python Sample/fatsever/app/static/js/chat.js
@@ -5,7 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const input = document.getElementById('messageInput');
   const send = document.getElementById('sendBtn');
 
-  const ws = new WebSocket(`ws://${location.host}/ws`);
+  const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(`${scheme}://${location.host}/ws`);
 
   ws.onmessage = (event) => {
     const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure WebSocket uses `wss` when the page is served over HTTPS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d7e349008330b1e1f433465d016b