### PR TITLE
Apply material design to fastapi server

### DIFF
--- a/Python Sample/fatsever/app/static/css/index.css
+++ b/Python Sample/fatsever/app/static/css/index.css
@@ -92,14 +92,29 @@ body.monokai {
 }
 
 /* 修改 navbar 風格 */
-body.monokai .navbar {
+body.monokai nav {
   background-color: #1e1e1e;
 }
 
-body.monokai .navbar-brand, 
-body.monokai .nav-link, 
-body.monokai .btn-outline-light {
+body.monokai nav a.brand-logo,
+body.monokai nav a,
+body.monokai #themeToggle {
   color: #f8f8f2;
+}
+
+/* chat 影像預覽 */
+#chatLog img {
+  max-width: 100%;
+  height: auto;
+  margin: 4px 0;
+}
+
+/* 讓暗黑模式切換圖示在導覽列中垂直置中 */
+nav #themeToggle {
+  display: flex;
+  align-items: center;
+  height: 64px;          /* 導覽列預設高度 */
+  padding: 0 15px;        /* 與其他連結保持一致 */
 }
 
 /* 其他元件設定可依需求調整 */

--- a/Python Sample/fatsever/app/static/js/chat.js
+++ b/Python Sample/fatsever/app/static/js/chat.js
@@ -10,7 +10,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   ws.onmessage = (event) => {
     const div = document.createElement('div');
-    div.textContent = event.data;
+    const msg = event.data.trim();
+    // 若訊息包含圖片 URL，則顯示預覽
+    if (/https?:\/\/\S+\.(?:png|jpe?g|gif|webp)/i.test(msg)) {
+      const img = document.createElement('img');
+      img.src = msg;
+      img.alt = msg;
+      img.style.maxWidth = '200px';
+      div.appendChild(img);
+    } else {
+      div.textContent = msg;
+    }
     log.appendChild(div);
     log.scrollTop = log.scrollHeight;
   };

--- a/Python Sample/fatsever/app/static/js/index.js
+++ b/Python Sample/fatsever/app/static/js/index.js
@@ -10,6 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const themeToggle = document.getElementById('themeToggle');
   const themeIcon = document.getElementById('themeIcon');
 
+  // 初始化 Materialize tabs
+  M.Tabs.init(document.querySelectorAll('.tabs'));
+
   // 初始化 dialog 變數
   imageDialog = document.getElementById('imageDialog');
   videoDialog = document.getElementById('videoDialog');

--- a/Python Sample/fatsever/app/templates/base.html
+++ b/Python Sample/fatsever/app/templates/base.html
@@ -4,37 +4,25 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>{% block title %}FatAPI{% endblock %}</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"/>
   <link rel="stylesheet" href="/assets/css/index.css"/>
 </head>
 <body>
   {% block navigation %}
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="/">FatAPI Server</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-              data-bs-target="#navbarNav" aria-controls="navbarNav"
-              aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse ms-auto" id="navbarNav">
-        <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-          <li class="nav-item">
-            <a class="nav-link" href="/">Home</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/chat">Chat</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/status">Status</a>
-          </li>
-        </ul>
-      </div>
-
-      <button id="themeToggle" class="btn btn-outline-light justify-content-end" aria-label="dark mode switch">
-        <i id="themeIcon" class="fas fa-sun"></i>
-      </button>
+  <nav class="blue">
+    <div class="nav-wrapper container">
+      <a href="/" class="brand-logo">FatAPI Server</a>
+      <ul id="nav-mobile" class="right">
+        <li><a href="/">Home</a></li>
+        <li><a href="/chat">Chat</a></li>
+        <li><a href="/status">Status</a></li>
+        <li>
+          <a id="themeToggle" class="btn-flat" aria-label="dark mode switch" href="#!">
+            <i id="themeIcon" class="fas fa-sun"></i>
+          </a>
+        </li>
+      </ul>
     </div>
   </nav>
   {% endblock navigation %}
@@ -64,7 +52,7 @@
     </div>
   </dialog>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
   <script src="/assets/js/index.js"></script>
 </body>
 </html>

--- a/Python Sample/fatsever/app/templates/chat.html
+++ b/Python Sample/fatsever/app/templates/chat.html
@@ -4,10 +4,14 @@
 <div class="container py-3">
   {% block content %}
   <h2 class="mb-3">Chat Room</h2>
-  <div id="chatLog" style="height:60vh;overflow-y:auto;border:1px solid #ccc;padding:10px;"></div>
-  <div class="input-group mt-3">
-    <input type="text" id="messageInput" class="form-control" placeholder="輸入訊息" autocomplete="off">
-    <button id="sendBtn" class="btn btn-primary">送出</button>
+  <div id="chatLog" class="z-depth-1" style="height:60vh;overflow-y:auto;padding:10px;"></div>
+  <div class="row valign-wrapper" style="margin-top:1rem;">
+    <div class="input-field col s10">
+      <input id="messageInput" type="text" placeholder="輸入訊息" autocomplete="off" />
+    </div>
+    <div class="col s2 right-align">
+      <a id="sendBtn" class="btn waves-effect waves-light">送出</a>
+    </div>
   </div>
   <script src="/assets/js/chat.js"></script>
   {% endblock content %}

--- a/Python Sample/fatsever/app/templates/home.html
+++ b/Python Sample/fatsever/app/templates/home.html
@@ -7,64 +7,49 @@
       
   <!-- ytdownloader 表單 -->
   <form id="ytDownloadForm" action="/api/ytdownloader" method="post" enctype="multipart/form-data" class="mb-4">
-    <div class="input-group">
-      <input type="text" 
-             id="youtubeUrl" 
-             name="url" 
-             class="form-control" 
-             placeholder="請輸入 YouTube 影片網址"
-             aria-label="YouTube URL">
-      <button class="btn btn-primary" type="submit" id="ytDownloadBtn">
-        <i class="fas fa-download me-2"></i>
-        <span>下載</span>
-        <i class="fas fa-spinner fa-spin" style="display: none;"></i>
-      </button>
+    <div class="row">
+      <div class="input-field col s12 m8">
+        <input type="text" id="youtubeUrl" name="url" placeholder="請輸入 YouTube 影片網址">
+      </div>
+      <div class="input-field col s12 m4">
+        <button class="btn waves-effect waves-light" type="submit" id="ytDownloadBtn">
+          <i class="fas fa-download left"></i>
+          <span>下載</span>
+          <i class="fas fa-spinner fa-spin" style="display:none;"></i>
+        </button>
+      </div>
     </div>
   </form>
 
   <!-- 上傳表單 -->
   <form id="uploadForm" action="/api/upload" method="post" enctype="multipart/form-data" class="mb-4">
-    <div class="mb-3">
-      <input class="form-control" type="file" id="file" name="file" multiple style="display: none;">
+    <div class="file-field input-field">
       <div class="drop-zone" id="dropZone">Drag & Drop files here or click to upload</div>
+      <input type="file" id="file" name="file" multiple style="display:none;">
     </div>
-    <button type="submit" class="btn btn-primary d-none">Upload File</button>
+    <button type="submit" class="btn waves-effect waves-light d-none">Upload File</button>
   </form>
 
   <!-- Tabs -->
-  <ul class="nav nav-tabs" id="fileTabs" role="tablist">
-    <li class="nav-item" role="presentation">
-      <button class="nav-link active" id="images-tab" data-bs-toggle="tab" data-bs-target="#images"
-              type="button" role="tab" aria-controls="images" aria-selected="true">
-        Images
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link" id="videos-tab" data-bs-toggle="tab" data-bs-target="#videos"
-              type="button" role="tab" aria-controls="videos" aria-selected="false">
-        Videos
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link" id="others-tab" data-bs-toggle="tab" data-bs-target="#others"
-              type="button" role="tab" aria-controls="others" aria-selected="false">
-        Others
-      </button>
-    </li>
-  </ul>
+  <div class="row">
+    <div class="col s12">
+      <ul class="tabs tabs-fixed-width" id="fileTabs">
+        <li class="tab col s4"><a href="#images" class="active">Images</a></li>
+        <li class="tab col s4"><a href="#videos">Videos</a></li>
+        <li class="tab col s4"><a href="#others">Others</a></li>
+      </ul>
+    </div>
+  </div>
 
   <!-- Tab contents -->
-  <div class="tab-content" id="fileTabsContent">
-    <!-- 圖片檔案 -->
-    <div class="tab-pane fade show active p-3" id="images" role="tabpanel"
-         aria-labelledby="images-tab">
-      <div id="imageGrid" class="row row-cols-2 row-cols-sm-3 row-cols-md-4 g-3">
+  <div id="images" class="col s12">
+    <div id="imageGrid" class="row">
         {% for file in img_files %}
-        <div class="col">
+        <div class="col s6 m4 l3">
           <div class="file-card" data-file="{{ file }}" data-type="image" title="{{ file }}">
             <img src="/img/{{ file }}" alt="{{ file }}" class="file-card-img">
-            <button class="btn btn-danger btn-sm delete-btn" 
-                    data-file="{{ file }}" 
+            <button class="btn btn-danger btn-sm delete-btn"
+                    data-file="{{ file }}"
                     data-type="image"
                     style="position: absolute; top: 5px; right: 5px;">
               <i class="fas fa-trash"></i>
@@ -73,13 +58,12 @@
         </div>
         {% endfor %}
       </div>
-    </div>
+  </div>
 
-    <!-- 影片檔案 -->
-    <div class="tab-pane fade p-3" id="videos" role="tabpanel" aria-labelledby="videos-tab">
-      <div id="videoGrid" class="row row-cols-2 row-cols-sm-3 row-cols-md-4 g-3">
+  <div id="videos" class="col s12">
+    <div id="videoGrid" class="row">
         {% for item in video_files %}
-        <div class="col">
+        <div class="col s6 m4 l3">
           <div class="file-card" data-file="{{ item.video }}" data-type="video">
             {% if item.thumbnail %}
             <img src="/video/{{ item.thumbnail }}" alt="{{ item.video }}" class="file-card-img">
@@ -89,8 +73,8 @@
             <div class="file-card-body">
               <p class="file-card-title">{{ item.video }}</p>
             </div>
-            <button class="btn btn-danger btn-sm delete-btn" 
-                    data-file="{{ item.video }}" 
+            <button class="btn btn-danger btn-sm delete-btn"
+                    data-file="{{ item.video }}"
                     data-type="video"
                     style="position: absolute; top: 5px; right: 5px;">
               <i class="fas fa-trash"></i>
@@ -99,20 +83,19 @@
         </div>
         {% endfor %}
       </div>
-    </div>
+  </div>
 
-    <!-- 其他檔案 -->
-    <div class="tab-pane fade p-3" id="others" role="tabpanel" aria-labelledby="others-tab">
-      <div id="otherGrid" class="row row-cols-2 row-cols-sm-3 row-cols-md-4 g-3">
+  <div id="others" class="col s12">
+    <div id="otherGrid" class="row">
         {% for file in other_files %}
-        <div class="col">
+        <div class="col s6 m4 l3">
           <a class="file-card" href="/files/{{ file }}" download data-file="{{ file }}" data-type="other">
             <div class="file-icon"></div>
             <div class="file-card-body">
               <p class="file-card-title">{{ file }}</p>
             </div>
-            <button class="btn btn-danger btn-sm delete-btn" 
-                    data-file="{{ file }}" 
+            <button class="btn btn-danger btn-sm delete-btn"
+                    data-file="{{ file }}"
                     data-type="other"
                     style="position: absolute; top: 5px; right: 5px;">
               <i class="fas fa-trash"></i>
@@ -121,7 +104,6 @@
         </div>
         {% endfor %}
       </div>
-    </div>
   </div>
   
   <!-- 圖片預覽用 dialog -->


### PR DESCRIPTION
## Summary
- replace Bootstrap with Materialize components
- convert templates to Materialize classes
- tweak CSS for dark theme
- init Materialize JS in index script
- fix dark mode icon alignment
- restore tab styling
- restore chat image previews and update chat page layout

## Testing
- `pytest -q`
- `git ls-files '*.py' | xargs -d '\n' python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_686738c501c083309a44bd6b6e9e1ba1