### PR TITLE
Fix reader-focus dark mode styles

### DIFF
--- a/Js Tip/chrom extensions/reader-focus-extension/content.js
+++ b/Js Tip/chrom extensions/reader-focus-extension/content.js
@@ -42,20 +42,27 @@
   // --- Dark Mode Helpers ---
   const DARK_STYLE_ID = 'extension-dark-mode-style';
   const DARK_CLASS_NAME = 'extension-dark-mode';
+  const DARK_CSS = `
+html.${DARK_CLASS_NAME},
+html.${DARK_CLASS_NAME} body,
+html.${DARK_CLASS_NAME} body *:not(img):not(video):not(canvas):not(svg):not(picture) {
+  background-color: #121212 !important;
+  color: #f0f0f0 !important;
+}
+html.${DARK_CLASS_NAME} table,
+html.${DARK_CLASS_NAME} th,
+html.${DARK_CLASS_NAME} td,
+html.${DARK_CLASS_NAME} hr {
+  border-color: #ffffff !important;
+}`;
 
   function applyDarkMode() {
     const html = document.documentElement;
     const existing = document.getElementById(DARK_STYLE_ID);
-    if (html.style.filter) html.style.filter = '';
-    document.querySelectorAll('[data-extensionoriginalfilter]').forEach(el => {
-      el.style.filter = el.dataset.extensionoriginalfilter;
-      delete el.dataset.extensionoriginalfilter;
-    });
     if (!existing) {
-      const css = `html.${DARK_CLASS_NAME},html.${DARK_CLASS_NAME} body,html.${DARK_CLASS_NAME} body *:not(img):not(video):not(canvas):not(svg):not(picture){background-color:#121212!important;color:#f0f0f0!important;}html.${DARK_CLASS_NAME} img,html.${DARK_CLASS_NAME} video,html.${DARK_CLASS_NAME} canvas,html.${DARK_CLASS_NAME} svg,html.${DARK_CLASS_NAME} picture{filter:invert(0.92) hue-rotate(180deg)!important;}`;
       const style = document.createElement('style');
       style.id = DARK_STYLE_ID;
-      style.textContent = css;
+      style.textContent = DARK_CSS;
       document.head.appendChild(style);
     }
     html.classList.add(DARK_CLASS_NAME);
@@ -66,11 +73,6 @@
     const existing = document.getElementById(DARK_STYLE_ID);
     html.classList.remove(DARK_CLASS_NAME);
     if (existing) existing.remove();
-    if (html.style.filter) html.style.filter = '';
-    document.querySelectorAll('[data-extensionoriginalfilter]').forEach(el => {
-      el.style.filter = el.dataset.extensionoriginalfilter;
-      delete el.dataset.extensionoriginalfilter;
-    });
   }
   // --- /Dark Mode Helpers ---
 

--- a/Js Tip/chrom extensions/reader-focus-extension/popup.js
+++ b/Js Tip/chrom extensions/reader-focus-extension/popup.js
@@ -164,12 +164,6 @@ document.addEventListener('DOMContentLoaded', function() {
           const className = 'extension-dark-mode';
           const html = document.documentElement;
           const existing = document.getElementById(styleId);
-          // 清理舊版 filter 實作遺留樣式
-          if (html.style.filter) html.style.filter = '';
-          document.querySelectorAll('[data-extensionoriginalfilter]').forEach(el => {
-            el.style.filter = el.dataset.extensionoriginalfilter;
-            delete el.dataset.extensionoriginalfilter;
-          });
           if (html.classList.contains(className)) {
             html.classList.remove(className);
             if (existing) existing.remove();
@@ -182,12 +176,11 @@ html.${className} body *:not(img):not(video):not(canvas):not(svg):not(picture) {
   background-color: #121212 !important;
   color: #f0f0f0 !important;
 }
-html.${className} img,
-html.${className} video,
-html.${className} canvas,
-html.${className} svg,
-html.${className} picture {
-  filter: invert(0.92) hue-rotate(180deg) !important;
+html.${className} table,
+html.${className} th,
+html.${className} td,
+html.${className} hr {
+  border-color: #ffffff !important;
 }`;
           const style = existing || document.createElement('style');
           style.id = styleId;


### PR DESCRIPTION
## Summary
- restore CSS-based dark mode so images stay unaffected
- ensure borders stay visible in dark theme

## Testing
- `node -c ./Js\ Tip/chrom\ extensions/reader-focus-extension/content.js`
- `node -c ./Js\ Tip/chrom\ extensions/reader-focus-extension/popup.js`

------
https://chatgpt.com/codex/tasks/task_e_686b1ce518648330941ca04c28876d09