### PR TITLE
Fix chat preview area

### DIFF
--- a/Python Sample/fatsever/app/static/js/chat.js
+++ b/Python Sample/fatsever/app/static/js/chat.js
@@ -79,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function showPreviewSide(el) {
+    if (!previewArea) return;
     previewArea.innerHTML = '';
     previewArea.appendChild(el);
   }

--- a/Python Sample/fatsever/app/templates/chat.html
+++ b/Python Sample/fatsever/app/templates/chat.html
@@ -4,7 +4,10 @@
 <div class="container py-3">
   {% block content %}
   <h2 class="mb-3">Chat Room</h2>
-  <div id="chatLog" class="z-depth-1" style="height:60vh;overflow-y:auto;padding:10px;"></div>
+  <div class="chat-layout">
+    <div id="chatLog" class="chat-log z-depth-1"></div>
+    <div id="previewArea" class="preview-area"></div>
+  </div>
   <div class="row valign-wrapper" style="margin-top:1rem;">
     <div class="input-field col s10">
       <input id="messageInput" type="text" placeholder="輸入訊息" autocomplete="off" />


### PR DESCRIPTION
## Summary
- fix chat page layout to include preview area
- avoid runtime error if preview container missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873a48097fc83308cb875a4d12de351