### PR TITLE
Fix dark mode chat input color

### DIFF
--- a/Python Sample/fatsever/app/static/css/index.css
+++ b/Python Sample/fatsever/app/static/css/index.css
@@ -238,3 +238,13 @@ body {
     display: none;
   }
 }
+/* Dark mode form fields */
+body.monokai input[type="text"],
+body.monokai textarea {
+  color: #f8f8f2;
+}
+
+body.monokai input[type="text"]::placeholder,
+body.monokai textarea::placeholder {
+  color: #ccc;
+}


### PR DESCRIPTION
## Summary
- adjust chat input color for dark theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873aa836d708330b0d9429ca0322ca8