### PR TITLE
fix dark mode form text color

### DIFF
--- a/Python Sample/fatsever/app/static/css/index.css
+++ b/Python Sample/fatsever/app/static/css/index.css
@@ -238,3 +238,11 @@ body {
     display: none;
   }
 }
+/* Dark mode form fields */
+body.monokai input:not([type="submit"]):not([type="file"]),
+body.monokai textarea {
+  color: #f8f8f2 !important;
+}
+body.monokai .input-field label {
+  color: #ccc;
+}

--- a/Python Sample/fatsever/app/templates/chat.html
+++ b/Python Sample/fatsever/app/templates/chat.html
@@ -4,6 +4,14 @@
 <div class="container py-3">
   {% block content %}
   <h2 class="mb-3">Chat Room</h2>
+  <div class="row valign-wrapper mb-2">
+    <div class="input-field col s10">
+      <input id="usernameInput" type="text" placeholder="輸入名字" autocomplete="off" />
+    </div>
+    <div class="col s2 right-align">
+      <a id="setNameBtn" class="btn waves-effect waves-light">設定</a>
+    </div>
+  </div>
   <div class="chat-layout">
     <div id="chatLog" class="chat-log z-depth-1"></div>
     <div id="previewArea" class="preview-area"></div>


### PR DESCRIPTION
## Summary
- broaden dark theme rule so all text inputs use light color
- confirm username input persists on chat page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873aa836d708330b0d9429ca0322ca8